### PR TITLE
storing_of_model_explorer_data_during_switching

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -125,6 +125,7 @@ tabPanel("model editor",icon=icon("bug"), # fa-leaf fa-bug
         column(6,
                helpText("Model editor:"),
                tags$textarea(id="model_input_area", rows=200, cols=300)
+               # textAreaInput("model_input_area",NULL,width=NULL,height=NULL,rows=200,cols=100,resize="both")
         ),
         column(6,
                helpText("Properties editor:"),


### PR DESCRIPTION
- data for plots are now stored during the switch between experiments
(by next, prev)
- param_sliders in model_explorer are now dependent on current
experiment number